### PR TITLE
refactor: centralize color palette

### DIFF
--- a/_includes/showcase.njk
+++ b/_includes/showcase.njk
@@ -6,23 +6,25 @@
     <title>{{ title }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
     <style>
         .story-body {
             font-family: monospace;
-            background-color: #1a1a1a;
-            color: #e0e0e0;
+            background-color: var(--background-color);
+            color: var(--text-color);
         }
         .nav-link {
             transition: all 0.2s ease-in-out;
+            color: var(--text-color);
         }
         .nav-link.active {
-            background-color: #333;
-            color: #ffb74d;
+            background-color: var(--primary-color);
+            color: var(--background-color);
             font-weight: 600;
         }
         .nav-link:not(.active):hover {
-            background-color: #2a2a2a;
-            color: #ffb74d;
+            background-color: var(--primary-color);
+            color: var(--background-color);
         }
         .content-section {
             display: none;
@@ -36,9 +38,9 @@
             to { opacity: 1; transform: translateY(0); }
         }
         .tab-btn.active {
-            border-color: #ffb74d;
-            background-color: #333;
-            color: #ffb74d;
+            border-color: var(--primary-color);
+            background-color: var(--primary-color);
+            color: var(--background-color);
         }
         .tab-content {
             display: none;
@@ -56,7 +58,7 @@
             top: 50%;
             transform: translateY(-50%);
             font-size: 2rem;
-            color: #555;
+            color: var(--muted-text-color);
         }
         .pipeline-step {
             position: relative;
@@ -69,15 +71,15 @@
             left: 50%;
             transform: translateX(-50%);
             font-size: 2rem;
-            color: #555;
+            color: var(--muted-text-color);
         }
     </style>
 </head>
 <body class="antialiased story-body">
     <div class="flex flex-col md:flex-row min-h-screen">
-        <aside class="w-full md:w-64 bg-[#111] border-r border-[#333] p-6">
-            <a href="/" class="text-lg text-gray-400 hover:text-[#ffb74d] transition-colors">← Back to Blog</a>
-            <h1 class="text-2xl font-bold text-white mt-4 mb-8">Project Showcase</h1>
+        <aside class="w-full md:w-64 bg-[var(--alt-background-color)] border-r border-[var(--border-color)] p-6">
+            <a href="/" class="text-lg text-[var(--muted-text-color)] hover:text-[var(--primary-color)] transition-colors">← Back to Blog</a>
+            <h1 class="text-2xl font-bold mt-4 mb-8">Project Showcase</h1>
             <nav id="main-nav" class="flex flex-row md:flex-col gap-2">
                 <a href="#slide1" class="nav-link p-3 rounded-lg text-left w-full">Introduction</a>
                 <a href="#slide2" class="nav-link p-3 rounded-lg text-left w-full">The Problem</a>

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,18 @@
 /* --- General & Typography --- */
 :root {
   --primary-color: #0d9488; /* Teal */
+  --background-color: #f8f9fa;
+  --text-color: #212529;
+  --heading-color: #343a40;
+  --muted-text-color: #6c757d;
+  --link-hover-color: #0f766e; /* Darker Teal */
+  --alt-background-color: #ffffff;
+  --border-color: #dee2e6;
+  --post-border-color: #e9ecef;
+  --footer-bg-color: #343a40;
+  --footer-text-color: #f8f9fa;
+  --footer-link-color: #adb5bd;
+  --secondary-text-color: #495057;
   --heading-font: 'Inter', sans-serif;
   --body-font: 'Lora', serif;
 }
@@ -10,8 +22,8 @@ body {
     line-height: 1.7;
     margin: 0;
     padding: 0;
-    background-color: #f8f9fa;
-    color: #212529;
+    background-color: var(--background-color);
+    color: var(--text-color);
     display: flex;
     flex-direction: column;
     min-height: 100vh;
@@ -19,7 +31,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--heading-font);
-    color: #343a40;
+    color: var(--heading-color);
     line-height: 1.3;
     font-weight: 700;
 }
@@ -31,7 +43,7 @@ a {
 }
 
 a:hover {
-    color: #0f766e; /* Darker Teal */
+    color: var(--link-hover-color);
 }
 
 /* --- Layout & Container --- */
@@ -49,8 +61,8 @@ main {
 
 /* --- Header --- */
 .site-header {
-    background-color: #ffffff;
-    border-bottom: 1px solid #dee2e6;
+    background-color: var(--alt-background-color);
+    border-bottom: 1px solid var(--border-color);
     padding: 1rem 0;
 }
 
@@ -68,7 +80,7 @@ main {
 .site-tagline {
     margin: 0;
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-family: var(--body-font);
     font-style: italic;
 }
@@ -76,7 +88,7 @@ main {
 /* --- Homepage Post List (Update) --- */
 .post-list-item {
     padding: 1.5rem 0;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .post-list-item:first-child {
@@ -95,7 +107,7 @@ main {
     font-size: 1.5rem;
     font-family: var(--heading-font);
     font-weight: 700;
-    color: #343a40;
+    color: var(--heading-color);
 }
 
 .post-list-item h2 a:hover {
@@ -105,16 +117,16 @@ main {
 .post-excerpt {
     margin-top: 0.5rem;
     margin-bottom: 0;
-    color: #495057;
+    color: var(--secondary-text-color);
     line-height: 1.6;
 }
 
 /* --- Single Post Article --- */
 .post {
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .post h1 {
@@ -124,7 +136,7 @@ main {
 
 .post .post-meta {
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     margin-bottom: 2rem;
     display: block;
 }
@@ -134,10 +146,10 @@ main {
 }
 
 .post-content blockquote {
-    border-left: 4px solid #007bff;
+    border-left: 4px solid var(--primary-color);
     padding-left: 1rem;
     margin: 2rem 0;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-style: italic;
 }
 
@@ -164,13 +176,13 @@ main {
 }
 
 .site-navigation a {
-    color: #343a40;
+    color: var(--heading-color);
     font-weight: 500;
     font-size: 1rem;
 }
 
 .site-navigation a:hover {
-    color: #007bff;
+    color: var(--primary-color);
 }
 
 /* --- About Page --- */
@@ -179,10 +191,10 @@ main {
     grid-template-columns: 1fr 2fr;
     gap: 2rem;
     align-items: start;
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .about-photo img {
@@ -198,7 +210,7 @@ main {
 
 .about-info h3 {
     margin-top: 2rem;
-    border-bottom: 2px solid #e9ecef;
+    border-bottom: 2px solid var(--post-border-color);
     padding-bottom: 0.5rem;
     font-weight: 700;
 }
@@ -209,7 +221,7 @@ main {
 }
 
 .interests-list li {
-    background-color: #f8f9fa;
+    background-color: var(--background-color);
     padding: 0.5rem 1rem;
     border-radius: 5px;
     margin-bottom: 0.5rem;
@@ -243,11 +255,11 @@ main {
 
 .social-links span {
     font-weight: bold;
-    color: #adb5bd;
+    color: var(--footer-link-color);
 }
 
 .social-links a {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
     text-decoration: none;
     transition: color 0.2s ease-in-out;
 }
@@ -258,14 +270,14 @@ main {
 
 .copyright {
     margin: 0;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-size: 0.875rem;
 }
 
 /* --- Footer --- */
 .site-footer {
-    background-color: #343a40;
-    color: #f8f9fa;
+    background-color: var(--footer-bg-color);
+    color: var(--footer-text-color);
     text-align: center;
     padding: 2rem 0;
     margin-top: auto;
@@ -278,10 +290,10 @@ main {
 
 /* --- Generic Page Content --- */
 .page-content {
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .page-content h1 {
@@ -291,13 +303,13 @@ main {
 
 .page-content h3 {
     margin-top: 2rem;
-    border-bottom: 2px solid #e9ecef;
+    border-bottom: 2px solid var(--post-border-color);
     padding-bottom: 0.5rem;
 }
 
 .last-updated {
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-style: italic;
     margin-top: -1.5rem;
     margin-bottom: 2rem;
@@ -318,13 +330,13 @@ main {
 }
 
 .footer-legal a {
-    color: #adb5bd;
+    color: var(--footer-link-color);
     text-decoration: none;
     font-size: 0.875rem;
 }
 
 .footer-legal a:hover {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
 }
 
 /* --- Update Main Footer Container --- */
@@ -370,13 +382,13 @@ img {
 }
 
 .footer-legal a {
-    color: #adb5bd;
+    color: var(--footer-link-color);
     text-decoration: none;
     font-size: 0.875rem;
 }
 
 .footer-legal a:hover {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
 }
 
 /* --- Update Main Footer Container --- */


### PR DESCRIPTION
## Summary
- centralize main site colors in CSS variables
- apply shared color scheme to showcase template using variables

## Testing
- `npm test` (fails: Error: no test specified)
- `npx @11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_6890bfe2fd30832f8761587bf45e6393