### PR TITLE
refactor: centralize color palette

### DIFF
--- a/_includes/showcase.njk
+++ b/_includes/showcase.njk
@@ -6,23 +6,25 @@
     <title>{{ title }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
     <style>
         .story-body {
             font-family: monospace;
-            background-color: #1a1a1a;
-            color: #e0e0e0;
+            background-color: var(--background-color);
+            color: var(--text-color);
         }
         .nav-link {
             transition: all 0.2s ease-in-out;
+            color: var(--text-color);
         }
         .nav-link.active {
-            background-color: #333;
-            color: #ffb74d;
+            background-color: var(--primary-color);
+            color: var(--background-color);
             font-weight: 600;
         }
         .nav-link:not(.active):hover {
-            background-color: #2a2a2a;
-            color: #ffb74d;
+            background-color: var(--primary-color);
+            color: var(--background-color);
         }
         .content-section {
             display: none;
@@ -36,9 +38,9 @@
             to { opacity: 1; transform: translateY(0); }
         }
         .tab-btn.active {
-            border-color: #ffb74d;
-            background-color: #333;
-            color: #ffb74d;
+            border-color: var(--primary-color);
+            background-color: var(--primary-color);
+            color: var(--background-color);
         }
         .tab-content {
             display: none;
@@ -56,7 +58,7 @@
             top: 50%;
             transform: translateY(-50%);
             font-size: 2rem;
-            color: #555;
+            color: var(--muted-text-color);
         }
         .pipeline-step {
             position: relative;
@@ -69,15 +71,15 @@
             left: 50%;
             transform: translateX(-50%);
             font-size: 2rem;
-            color: #555;
+            color: var(--muted-text-color);
         }
     </style>
 </head>
 <body class="antialiased story-body">
     <div class="flex flex-col md:flex-row min-h-screen">
-        <aside class="w-full md:w-64 bg-[#111] border-r border-[#333] p-6">
-            <a href="/" class="text-lg text-gray-400 hover:text-[#ffb74d] transition-colors">← Back to Blog</a>
-            <h1 class="text-2xl font-bold text-white mt-4 mb-8">Project Showcase</h1>
+        <aside class="w-full md:w-64 bg-[var(--alt-background-color)] border-r border-[var(--border-color)] p-6">
+            <a href="/" class="text-lg text-[var(--muted-text-color)] hover:text-[var(--primary-color)] transition-colors">← Back to Blog</a>
+            <h1 class="text-2xl font-bold mt-4 mb-8">Project Showcase</h1>
             <nav id="main-nav" class="flex flex-row md:flex-col gap-2">
                 <a href="#slide1" class="nav-link p-3 rounded-lg text-left w-full">Introduction</a>
                 <a href="#slide2" class="nav-link p-3 rounded-lg text-left w-full">The Problem</a>

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,18 @@
 /* --- General & Typography --- */
 :root {
   --primary-color: #0d9488; /* Teal */
+  --background-color: #f8f9fa;
+  --text-color: #212529;
+  --heading-color: #343a40;
+  --muted-text-color: #6c757d;
+  --link-hover-color: #0f766e; /* Darker Teal */
+  --alt-background-color: #ffffff;
+  --border-color: #dee2e6;
+  --post-border-color: #e9ecef;
+  --footer-bg-color: #343a40;
+  --footer-text-color: #f8f9fa;
+  --footer-link-color: #adb5bd;
+  --secondary-text-color: #495057;
   --heading-font: 'Inter', sans-serif;
   --body-font: 'Lora', serif;
 }
@@ -10,8 +22,8 @@ body {
     line-height: 1.7;
     margin: 0;
     padding: 0;
-    background-color: #f8f9fa;
-    color: #212529;
+    background-color: var(--background-color);
+    color: var(--text-color);
     display: flex;
     flex-direction: column;
     min-height: 100vh;
@@ -19,7 +31,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--heading-font);
-    color: #343a40;
+    color: var(--heading-color);
     line-height: 1.3;
     font-weight: 700;
 }
@@ -31,7 +43,7 @@ a {
 }
 
 a:hover {
-    color: #0f766e; /* Darker Teal */
+    color: var(--link-hover-color);
 }
 
 /* --- Layout & Container --- */
@@ -49,8 +61,8 @@ main {
 
 /* --- Header --- */
 .site-header {
-    background-color: #ffffff;
-    border-bottom: 1px solid #dee2e6;
+    background-color: var(--alt-background-color);
+    border-bottom: 1px solid var(--border-color);
     padding: 1rem 0;
 }
 
@@ -68,7 +80,7 @@ main {
 .site-tagline {
     margin: 0;
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-family: var(--body-font);
     font-style: italic;
 }
@@ -76,7 +88,7 @@ main {
 /* --- Homepage Post List (Update) --- */
 .post-list-item {
     padding: 1.5rem 0;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .post-list-item:first-child {
@@ -95,7 +107,7 @@ main {
     font-size: 1.5rem;
     font-family: var(--heading-font);
     font-weight: 700;
-    color: #343a40;
+    color: var(--heading-color);
 }
 
 .post-list-item h2 a:hover {
@@ -105,16 +117,16 @@ main {
 .post-excerpt {
     margin-top: 0.5rem;
     margin-bottom: 0;
-    color: #495057;
+    color: var(--secondary-text-color);
     line-height: 1.6;
 }
 
 /* --- Single Post Article --- */
 .post {
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .post h1 {
@@ -124,7 +136,7 @@ main {
 
 .post .post-meta {
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     margin-bottom: 2rem;
     display: block;
 }
@@ -134,10 +146,10 @@ main {
 }
 
 .post-content blockquote {
-    border-left: 4px solid #007bff;
+    border-left: 4px solid var(--primary-color);
     padding-left: 1rem;
     margin: 2rem 0;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-style: italic;
 }
 
@@ -164,13 +176,13 @@ main {
 }
 
 .site-navigation a {
-    color: #343a40;
+    color: var(--heading-color);
     font-weight: 500;
     font-size: 1rem;
 }
 
 .site-navigation a:hover {
-    color: #007bff;
+    color: var(--primary-color);
 }
 
 /* --- About Page --- */
@@ -179,10 +191,10 @@ main {
     grid-template-columns: 1fr 2fr;
     gap: 2rem;
     align-items: start;
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .about-photo img {
@@ -198,7 +210,7 @@ main {
 
 .about-info h3 {
     margin-top: 2rem;
-    border-bottom: 2px solid #e9ecef;
+    border-bottom: 2px solid var(--post-border-color);
     padding-bottom: 0.5rem;
     font-weight: 700;
 }
@@ -209,7 +221,7 @@ main {
 }
 
 .interests-list li {
-    background-color: #f8f9fa;
+    background-color: var(--background-color);
     padding: 0.5rem 1rem;
     border-radius: 5px;
     margin-bottom: 0.5rem;
@@ -243,11 +255,11 @@ main {
 
 .social-links span {
     font-weight: bold;
-    color: #adb5bd;
+    color: var(--footer-link-color);
 }
 
 .social-links a {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
     text-decoration: none;
     transition: color 0.2s ease-in-out;
 }
@@ -258,14 +270,14 @@ main {
 
 .copyright {
     margin: 0;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-size: 0.875rem;
 }
 
 /* --- Footer --- */
 .site-footer {
-    background-color: #343a40;
-    color: #f8f9fa;
+    background-color: var(--footer-bg-color);
+    color: var(--footer-text-color);
     text-align: center;
     padding: 2rem 0;
     margin-top: auto;
@@ -278,10 +290,10 @@ main {
 
 /* --- Generic Page Content --- */
 .page-content {
-    background-color: #ffffff;
+    background-color: var(--alt-background-color);
     padding: 2rem;
     border-radius: 8px;
-    border: 1px solid #e9ecef;
+    border: 1px solid var(--post-border-color);
 }
 
 .page-content h1 {
@@ -291,13 +303,13 @@ main {
 
 .page-content h3 {
     margin-top: 2rem;
-    border-bottom: 2px solid #e9ecef;
+    border-bottom: 2px solid var(--post-border-color);
     padding-bottom: 0.5rem;
 }
 
 .last-updated {
     font-size: 0.9rem;
-    color: #6c757d;
+    color: var(--muted-text-color);
     font-style: italic;
     margin-top: -1.5rem;
     margin-bottom: 2rem;
@@ -318,13 +330,13 @@ main {
 }
 
 .footer-legal a {
-    color: #adb5bd;
+    color: var(--footer-link-color);
     text-decoration: none;
     font-size: 0.875rem;
 }
 
 .footer-legal a:hover {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
 }
 
 /* --- Update Main Footer Container --- */
@@ -370,13 +382,13 @@ img {
 }
 
 .footer-legal a {
-    color: #adb5bd;
+    color: var(--footer-link-color);
     text-decoration: none;
     font-size: 0.875rem;
 }
 
 .footer-legal a:hover {
-    color: #f8f9fa;
+    color: var(--footer-text-color);
 }
 
 /* --- Update Main Footer Container --- */

--- a/showcase.md
+++ b/showcase.md
@@ -5,14 +5,14 @@ title: Showcase | The Story Behind the Blog
 
 <section id="slide1" class="content-section">
     <div class="max-w-4xl mx-auto text-center flex flex-col items-center justify-center h-full">
-        <h1 class="text-5xl md:text-6xl font-bold text-white leading-tight">How I Built an Automated Content Factory with an AI Assistant</h1>
+        <h1 class="text-5xl md:text-6xl font-bold text-[var(--heading-color)] leading-tight">How I Built an Automated Content Factory with an AI Assistant</h1>
         <p class="mt-4 text-xl md:text-2xl text-gray-400">You don't need to be a coder to build things anymore.</p>
         <p class="mt-8 text-lg font-semibold text-gray-300">By Daniel Zirpoli (aka AIficionado)</p>
     </div>
 </section>
 
 <section id="slide2" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-6">The Problem: The Manual Content Grind</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-6">The Problem: The Manual Content Grind</h2>
     <div class="space-y-4 text-lg max-w-3xl">
         <p>The process of creating a high-quality blog post from a simple idea is incredibly time-consuming. It's a journey filled with manual, repetitive steps.</p>
         <ul class="list-disc list-inside space-y-3 pl-4 pt-2">
@@ -26,7 +26,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="slide3" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-8">The Solution: A Team of AI Specialists</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-8">The Solution: A Team of AI Specialists</h2>
     <div class="space-y-4 text-lg max-w-3xl">
         <p>Instead of one giant, monolithic program, I created a team of three specialists that work together. This is known as a "microservices" architecture, where each program does one job really well. This design made it much easier for me to make changes to one part without breaking another.</p>
     </div>
@@ -53,7 +53,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="slide4" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-8">Meet the Team</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-8">Meet the Team</h2>
     <div id="team-tabs" class="mb-6 flex flex-wrap gap-2 border-b border-[#333]">
         <button class="tab-btn py-3 px-6 text-lg font-medium border-b-4 border-transparent hover:bg-[#2a2a2a] hover:text-[#ffb74d]" data-tab="kurator">kurator</button>
         <button class="tab-btn py-3 px-6 text-lg font-medium border-b-4 border-transparent hover:bg-[#2a2a2a] hover:text-[#ffb74d]" data-tab="blogplus">blogplus</button>
@@ -85,7 +85,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="slide7" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-6">The "Magic" Isn't Code, It's Instructions</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-6">The "Magic" Isn't Code, It's Instructions</h2>
     <div class="space-y-4 text-lg max-w-3xl">
         <p>This is the core message. How did I, a "non-coder," build this? I didn't write thousands of lines of code. I wrote **instructions in plain English.** The "source code" for the AI's behavior lives in simple text files.</p>
         <p>My primary job was to be a good **manager and communicator**, clearly defining the goals for my AI assistant.</p>
@@ -102,7 +102,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="slide8" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-6">The Result: A Human-AI Partnership</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-6">The Result: A Human-AI Partnership</h2>
     <div class="space-y-4 text-lg max-w-3xl">
         <p>The final output is more than just an automated article; it's the product of a collaboration. The system *does* automate the creation process, but the highest quality result comes from a partnership.</p>
         <p>The AI handles the heavy lifting of drafting and structuring, but a handcrafted final touch from a human editor is what ensures the quality. This system doesn't replace the creator; it empowers them to be a director and editor, focusing on what matters most: the ideas, the message, and the quality that automation alone can't achieve.</p>
@@ -120,7 +120,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="automation" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-8">Full Automation: The Publishing Pipeline</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-8">Full Automation: The Publishing Pipeline</h2>
     <div class="space-y-4 text-lg max-w-3xl mb-12">
         <p>This isn't just a set of scripts I run manually. The entire system is deployed as a hands-free, automated pipeline that publishes content without any intervention.</p>
     </div>
@@ -155,7 +155,7 @@ title: Showcase | The Story Behind the Blog
 </section>
   
 <section id="next" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-6">What's Next? The Road Ahead</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-6">What's Next? The Road Ahead</h2>
     <div class="space-y-8 text-lg max-w-3xl">
         <div>
             <h3 class="text-2xl font-semibold text-gray-400 mb-3">1. Fully Automated Image Generation</h3>
@@ -177,7 +177,7 @@ title: Showcase | The Story Behind the Blog
 </section>
 
 <section id="slide9" class="content-section">
-    <h2 class="text-4xl font-bold text-white mb-6">Conclusion: The Future is Augmentation, Not Obsolescence</h2>
+    <h2 class="text-4xl font-bold text-[var(--heading-color)] mb-6">Conclusion: The Future is Augmentation, Not Obsolescence</h2>
     <div class="space-y-6 text-xl max-w-3xl">
         <p>This project proves that AI's true power isn't in replacing humans, but in augmenting our abilities. It's a tool that changes the nature of our work for the better.</p>
         <p class="text-2xl font-semibold text-gray-400 p-6 border-l-4 border-[#444] bg-[#222] rounded-r-lg">This doesn't make writers or coders obsolete. It makes them <span class="text-white">architects and quality editors.</span> A purely automated result won't be as good as one that's handcrafted. The key skill is shifting from pure execution to strategic direction and refinement.</p>


### PR DESCRIPTION
## Summary
- centralize main site colors in CSS variables
- apply shared color scheme to showcase template using variables
- darken showcase headlines to use shared heading color for readability

## Testing
- `npm test` (fails: Error: no test specified)
- `npx @11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_6890bfe2fd30832f8761587bf45e6393