### PR TITLE
Add post navigation links and styling

### DIFF
--- a/_includes/post.njk
+++ b/_includes/post.njk
@@ -7,4 +7,16 @@ layout: base.njk
   <div class="post-content">
     {{ content | safe }}
   </div>
+
+  <nav class="post-navigation">
+    {% set prev = collections.posts | getPreviousCollectionItem(page) %}
+    {% set next = collections.posts | getNextCollectionItem(page) %}
+    {% if prev %}
+      <a href="{{ prev.url }}">← Previous</a>
+    {% endif %}
+    <a href="/">Back to Home</a>
+    {% if next %}
+      <a href="{{ next.url }}">Next →</a>
+    {% endif %}
+  </nav>
 </article>

--- a/css/style.css
+++ b/css/style.css
@@ -173,6 +173,17 @@ main {
 
 }
 
+.post-navigation {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.post-navigation a {
+    font-weight: 500;
+}
+
 /* --- Header Navigation (Update) --- */
 .site-header .container {
     display: flex;


### PR DESCRIPTION
## Summary
- add previous/home/next navigation for blog posts
- style post navigation to match minimalist theme

## Testing
- `npm test` (fails: Error: no test specified)
- `npx @11ty/eleventy --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6890defdbf00832f9b520909803a55e3