### PR TITLE
Fix post navigation collection name

### DIFF
--- a/_includes/post.njk
+++ b/_includes/post.njk
@@ -9,8 +9,8 @@ layout: base.njk
   </div>
 
   <nav class="post-navigation">
-    {% set prev = collections.posts | getPreviousCollectionItem(page) %}
-    {% set next = collections.posts | getNextCollectionItem(page) %}
+    {% set prev = collections.post | getPreviousCollectionItem(page) %}
+    {% set next = collections.post | getNextCollectionItem(page) %}
     {% if prev %}
       <a href="{{ prev.url }}">← Previous</a>
     {% endif %}


### PR DESCRIPTION
## Summary
- Fix Eleventy post navigation by using `collections.post` in `_includes/post.njk`.

## Testing
- `npx @11ty/eleventy`


------
https://chatgpt.com/codex/tasks/task_e_6890e37ec1c0832fa2297d37e6a158a8