### PR TITLE
Add hover transitions to posts, buttons and navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,11 @@ a:hover {
     color: var(--link-hover-color);
 }
 
+/* --- Buttons --- */
+button {
+    transition: all 0.2s ease;
+}
+
 /* --- Layout & Container --- */
 .container {
     max-width: 800px;
@@ -95,6 +100,7 @@ main {
 .post-list-item {
     padding: 1.5rem 0;
     border-bottom: 1px solid var(--border-color);
+    transition: all 0.2s ease;
 }
 
 .post-list-item:first-child {
@@ -219,19 +225,36 @@ main {
     padding: 0.25rem 0.5rem;
     border: 1px solid transparent;
     border-radius: 4px;
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    transition: all 0.2s ease;
 }
 
-.site-navigation a:hover,
+@media (hover: hover) {
+    .post-list-item:hover {
+        background-color: var(--alt-background-color);
+        transform: translateY(-2px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+    button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    .site-navigation a:hover {
+        color: var(--primary-color);
+        background-color: var(--border-color);
+        border-color: var(--border-color);
+        transform: translateY(-2px);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+}
+
 .site-navigation a:focus {
     color: var(--primary-color);
     background-color: var(--border-color);
     border-color: var(--border-color);
-}
-
-.site-navigation a:focus {
     outline: 2px solid var(--primary-color);
     outline-offset: 2px;
+    transform: translateY(-2px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 /* --- About Page --- */


### PR DESCRIPTION
## Summary
- Smooth transitions for post list items, buttons and navigation links
- Subtle hover transforms and shadows applied only on hover-capable devices

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689101077e80832fa0a57146c40fe753