### PR TITLE
Add client-side search with Lunr

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -22,6 +22,7 @@
                     <li><a href="/about/">About</a></li>
                     <li><a href="/showcase/" target="_blank" rel="noopener noreferrer">Showcase</a></li>
                     <li><a href="/now/">Now</a></li>
+                    <li><a href="/search/">Search</a></li>
                 </ul>
             </nav>
         </header>

--- a/search.json.njk
+++ b/search.json.njk
@@ -1,0 +1,9 @@
+---
+permalink: /search.json
+eleventyExcludeFromCollections: true
+---
+[
+{% for post in collections.post %}
+  {"title": {{ post.data.title | dump }}, "url": {{ post.url | dump }} }{% if not loop.last %},{% endif %}
+{% endfor %}
+]

--- a/search.njk
+++ b/search.njk
@@ -1,0 +1,51 @@
+---
+title: Search
+layout: base.njk
+permalink: /search/
+---
+<h1>Search</h1>
+<input type="search" id="searchInput" placeholder="Search posts..." />
+<ul id="searchResults"></ul>
+
+<script src="https://cdn.jsdelivr.net/npm/lunr/lunr.min.js"></script>
+<script>
+let index, posts;
+const searchInput = document.getElementById('searchInput');
+const resultsList = document.getElementById('searchResults');
+
+fetch('/search.json')
+  .then(res => res.json())
+  .then(data => {
+    posts = data;
+    index = lunr(function () {
+      this.field('title');
+      this.ref('url');
+      posts.forEach(post => this.add(post));
+    });
+  });
+
+function displayResults(results) {
+  resultsList.innerHTML = '';
+  results.forEach(r => {
+    const post = posts.find(p => p.url === r.ref);
+    if (post) {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = post.url;
+      a.textContent = post.title;
+      li.appendChild(a);
+      resultsList.appendChild(li);
+    }
+  });
+}
+
+searchInput.addEventListener('input', () => {
+  const query = searchInput.value.trim();
+  if (!query || !index) {
+    resultsList.innerHTML = '';
+    return;
+  }
+  const results = index.search(query);
+  displayResults(results);
+});
+</script>


### PR DESCRIPTION
## Summary
- add search page with Lunr-powered client-side search
- generate `search.json` index of post titles and URLs
- link new search page from site navigation

## Testing
- `npx @11ty/eleventy`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689101038618832fa13776410d2c29c2