### PR TITLE
feat: add post thumbnail support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,6 +31,15 @@ module.exports = function(eleventyConfig) {
     return content.slice(0, 180) + "...";
   });
 
+  // Custom filter to extract the first image source for a thumbnail
+  eleventyConfig.addFilter("postThumbnail", (post) => {
+    if (!post || !post.templateContent) {
+      return "";
+    }
+    const match = post.templateContent.match(/<img\s+[^>]*src=['"]([^'"]+)['"][^>]*>/i);
+    return match ? match[1] : "";
+  });
+
   // Passthrough copy for static assets
   eleventyConfig.addPassthroughCopy("css");
   eleventyConfig.addPassthroughCopy("images");
@@ -41,5 +50,6 @@ module.exports = function(eleventyConfig) {
 
   return {
     dir: { input: ".", includes: "_includes", output: "_site" },
+    markdownTemplateEngine: "njk",
   };
 };

--- a/css/style.css
+++ b/css/style.css
@@ -98,6 +98,8 @@ main {
     padding: 1.5rem 0;
     border-bottom: 1px solid var(--border-color);
     transition: all 0.2s ease;
+    display: flex;
+    align-items: flex-start;
 }
 
 .post-list-item:first-child {
@@ -128,6 +130,26 @@ main {
     margin-bottom: 0;
     color: var(--secondary-text-color);
     line-height: 1.6;
+}
+
+/* Thumbnail image for post previews */
+.post-thumb {
+    width: 150px;
+    height: auto;
+    margin-right: 1rem;
+    flex-shrink: 0;
+}
+
+/* Allow optional right alignment */
+.post-thumb.right {
+    order: 1;
+    margin-right: 0;
+    margin-left: 1rem;
+}
+
+/* Container for text content next to the thumbnail */
+.post-list-content {
+    flex: 1;
 }
 
 /* --- Single Post Article --- */

--- a/index.md
+++ b/index.md
@@ -7,11 +7,17 @@ layout: base.njk
 <ul class="post-list">
 {%- for post in collections.post | reverse -%}
   <li class="post-list-item">
-    <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
-    <span class="post-date">{{ post.date | readableDate }}</span>
-    <p class="post-excerpt">
-      {{ post | postExcerpt }}
-    </p>
+    {% set thumb = post | postThumbnail %}
+    {% if thumb %}
+    <img class="post-thumb" src="{{ thumb }}" alt="{{ post.data.title }}">
+    {% endif %}
+    <div class="post-list-content">
+      <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+      <span class="post-date">{{ post.date | readableDate }}</span>
+      <p class="post-excerpt">
+        {{ post | postExcerpt }}
+      </p>
+    </div>
   </li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
## Summary
- add `postThumbnail` filter for pulling first image src
- show optional thumbnail in post listing
- style post list for side-by-side previews

## Testing
- `npm test` (fails: no test specified)
- `npx @11ty/eleventy --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6891fe66cf4c832fa1c0aac8ca393af0